### PR TITLE
Resolve $HOME in profile.d at runtime rather than during the build

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -9,16 +9,16 @@ PANDOC_FILENAME="pandoc-2.11.1.1-linux-amd64.tar.gz"
 PANDOC_URL="https://github.com/jgm/pandoc/releases/download/2.11.1.1/$PANDOC_FILENAME"
 VENDOR_DIR="$BUILD_DIR/vendor"
 BIN_DIR="$VENDOR_DIR/pandoc/bin"
-REAL_DIR="$HOME/vendor/pandoc/bin"
+RUNTIME_DIR="\$HOME/vendor/pandoc/bin"
 PANDOC_PKG="$CACHE_DIR/$PANDOC_FILENAME"
 
-mkdir -p $BUILD_DIR $CACHE_DIR $VENDOR_DIR $BIN_DIR $REAL_DIR
+mkdir -p $BUILD_DIR $CACHE_DIR $VENDOR_DIR $BIN_DIR
 
 echo "BUILD_DIR: $BUILD_DIR"
 echo "CACHE_DIR: $CACHE_DIR"
 echo "VENDOR_DIR: $VENDOR_DIR"
 echo "BIN_DIR: $BIN_DIR"
-echo "REAL_DIR: $REAL_DIR"
+echo "RUNTIME_DIR: $RUNTIME_DIR"
 
 if [ -f $PANDOC_PKG ]; then
   echo "Using cached pandoc pkg: $PANDOC_PKG"
@@ -42,7 +42,7 @@ ls -lR $BIN_DIR
 
 PROFILE_PATH="$BUILD_DIR/.profile.d/pandoc.sh"
 mkdir -p $(dirname $PROFILE_PATH)
-echo "export PATH=$REAL_DIR:\$PATH" > $PROFILE_PATH
+echo "export PATH=$RUNTIME_DIR:\$PATH" > $PROFILE_PATH
 
 echo "created $PROFILE_PATH:"
 cat $PROFILE_PATH


### PR DESCRIPTION
Hi! I'm on the team that maintains Heroku's build system.

In the next week or so we plan on changing the value for `$HOME` at build time as part of moving where the build occurs, however this buildpack has been found to not be compatible with this change.

This PR is a rebase of the fix for this compatibility issue from the upstream repository from which this repo was forked:
https://github.com/illustrativemathematics/pandoc-buildpack/pull/7

---

Previously the value for `$HOME` was resolved at build time, meaning its actual value during the build is hardcoded in the `.profile.d/` script, rather than just the variable name.

Whilst the value for `$HOME` is currently the same at both build-time and run-time (both `/app`), the build-time value (only) is due to change in the future to a path under `/tmp`.

By escaping the dollar sign, the variable `$HOME` is now resolved at runtime, making the buildpack compatible with this future change.

The mkdir of that directory has been removed, since it's unnecessary (nothing is put there during the build, it exists only at runtime).

For more information, see this issue on the upstream repo:
https://github.com/illustrativemathematics/pandoc-buildpack/issues/6